### PR TITLE
Rename to "The Linguistic Flux Capacitor"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "flux-capacitor"
+version = "0.0.1"
+dependencies = [
+ "byteorder",
+ "compressed_dynamic_word_embeddings",
+ "failure",
+ "log",
+ "ndarray",
+ "ndarray-npy",
+ "stderrlog",
+ "structopt",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,7 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
-name = "linguistic-time-capsule-backend"
+name = "linguistic-flux-capacitor-backend"
 version = "0.0.1"
 dependencies = [
  "byteorder",
@@ -1126,20 +1140,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "time-capsule"
-version = "0.0.1"
-dependencies = [
- "byteorder",
- "compressed_dynamic_word_embeddings",
- "failure",
- "log",
- "ndarray",
- "ndarray-npy",
- "stderrlog",
- "structopt",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# The Linguistic Time Capsule
+# The Linguistic Flux Capacitor
 
-The Linguistic time Capsule is a free web application that lets you explore how the meaning of words in the English language has changed over the past two centuries.
+The Linguistic Flux Capacitor is a free web application that lets you explore how the meaning of words in the English language has changed over the past two centuries.
 
 **Try it out (no installation required):**
-<https://robamler.github.io/linguistic-time-capsule>
+<https://robamler.github.io/linguistic-flux-capacitor>
 
 The app is a technical demonstration of what can be done when you combine a [probabilistic natural language model](https://robamler.github.io/files/bamler-dynamic-word-embeddings-icml-2017.pdf) with a [novel compression algorithm](https://robamler.github.io/files/yang-vbq-icml-2020.pdf).
 The app runs a machine learning model with 600 million parameters directly in your browser by leveraging WebAssembly (wasm) and a novel compression algorithm called [Variational Bayesian Quantization](https://robamler.github.io/files/yang-vbq-icml-2020.pdf).
@@ -24,7 +24,7 @@ Technical details are described in the following papers:
 
 ## Lightweight Explanation
 
-If the above scientific papers are too dense then you can find a more informal blog-post-style explanation of the employed techniques [on the app website](https://robamler.github.io/linguistic-time-capsule) (just scroll down from the app).
+If the above scientific papers are too dense then you can find a more informal blog-post-style explanation of the employed techniques [on the app website](https://robamler.github.io/linguistic-flux-capacitor) (just scroll down from the app).
 
 ## Contributing
 
@@ -33,7 +33,7 @@ If you're interested in more complex contributions I recommend [reaching out to 
 
 ### License
 
-The source code of The Linguistic Time Capsule is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
+The source code of The Linguistic Flux Capacitor is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 See files [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 If you open a pull request, we will interpret this as consent that your contributions may be licensed under the same existing terms unless you explicitly express your objection in the description of the pull request.
 
@@ -55,10 +55,10 @@ Before coding on this app, I strongly recommend going through the [Rust and Weba
 
 ### Installing Required Software
 
-To code on the Linguistic Time Capsule, set up a development environment as follows:
+To code on the Linguistic Flux Capacitor, set up a development environment as follows:
 
 1. [Install the Rust toolchain](https://rustup.rs/).
-   The Linguistic Time Capsule uses Rust (compiled to WebAssembly) for performance critical tasks like decompressing and running the machine learning model.
+   The Linguistic Flux Capacitor uses Rust (compiled to WebAssembly) for performance critical tasks like decompressing and running the machine learning model.
    - If Rust is already installed on your system, make sure you have the latest version by running `rustup update`.
 2. [Install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/).
    Wasm-pack is a tool that generates glue code between JavaScript and Rust generated WebAssembly.
@@ -76,27 +76,27 @@ The following steps need to be done only once in order to set up the project.
 
 1. Clone the Github repository:
    ```bash
-   git clone git@github.com:robamler/linguistic-time-capsule.git
+   git clone git@github.com:robamler/linguistic-flux-capacitor.git
    ```
 3. Build the backend:
    ```bash
-   cd linguistic-time-capsule/wasm
+   cd linguistic-flux-capacitor/wasm
    wasm-pack build
    ```
    This may take up to a few minutes when run for the first time because it has to compile all the dependencies.
    Subsequent compilations will be much faster because compiled dependencies will be cached.
-   - If you use VS Code and open it in the directory `linguistic-time-capsule` then this command should be available as the task "wasm-pack build" (use `Ctrl+Shift+P` → "Run Task" → "wasm-pack build").
+   - If you use VS Code and open it in the directory `linguistic-flux-capacitor` then this command should be available as the task "wasm-pack build" (use `Ctrl+Shift+P` → "Run Task" → "wasm-pack build").
 4. (Locally) install dependencies of the frontend (such as Webpack):
    ```bash
-   cd linguistic-time-capsule/wasm/www
+   cd linguistic-flux-capacitor/wasm/www
    npm install
    ```
 5. Compile the frontend and run a server that serves the app and observes changes to the source code:
    ```bash
-   cd linguistic-time-capsule/wasm/www
+   cd linguistic-flux-capacitor/wasm/www
    npm run serve
    ```
-   - If you use VS Code and open it in the directory `linguistic-time-capsule` then this command should be available as the task "npm: serve" (use `Ctrl+Shift+P` → "Run Task" → "npm: serve").
+   - If you use VS Code and open it in the directory `linguistic-flux-capacitor` then this command should be available as the task "npm: serve" (use `Ctrl+Shift+P` → "Run Task" → "npm: serve").
 6. Open a web browser at the URL printed by the above program.
    By default, it'll be http://localhost:8080/.
 
@@ -107,7 +107,7 @@ When you come back later to work on the app, the only required steps are:
 
 1. Start the Webpack server:
    ```bash
-   cd linguistic-time-capsule/wasm/www
+   cd linguistic-flux-capacitor/wasm/www
    npm run serve
    ```
    (Or simply run the task "npm: serve" from within VS Code: `Ctrl+Shift+P` → "Run Task" → "npm: serve".)
@@ -122,7 +122,7 @@ simply save the HTML, CSS, or JavaScript file.
 - For **backend development**:
 if you make any changes to Rust source files (`*.rs`) then you'll have to recompile the WebAssembly module:
   ```bash
-  cd linguistic-time-capsule/wasm
+  cd linguistic-flux-capacitor/wasm
   wasm-pack build
   ```
   (Or simply run the task "wasm-pack build" from within VS Code: `Ctrl+Shift+P` → "Run Task" → "wasm-pack build".)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "time-capsule"
-version = "0.0.1"
 authors = ["Robert Bamler <robert.bamler@gmail.com>"]
 edition = "2018"
+name = "flux-capacitor"
+version = "0.0.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compressed_dynamic_word_embeddings = { path = "../compressed_dynamic_word_embeddings" }
-log = { version="0.4.8", features=["std"] }
-stderrlog = "0.4.3"
-structopt = "0.3.7"
-failure = "0.1.6"
 byteorder = "1.3.2"
+compressed_dynamic_word_embeddings = {path = "../compressed_dynamic_word_embeddings"}
+failure = "0.1.6"
+log = {version = "0.4.8", features = ["std"]}
 ndarray = "0.13.1"
 ndarray-npy = "0.6"
+stderrlog = "0.4.3"
+structopt = "0.3.7"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -3,8 +3,8 @@ authors = ["Robert Bamler <robert.bamler@gmail.com>"]
 description = "Provides access to compressed dynamic word embeddings files from WebAssembly."
 edition = "2018"
 license = "MIT OR Apache-2.0"
-name = "linguistic-time-capsule-backend"
-repository = "https://github.com/robamler/linguistic-time-capsule.git"
+name = "linguistic-flux-capacitor-backend"
+repository = "https://github.com/robamler/linguistic-flux-capacitor.git"
 version = "0.0.1"
 
 [lib]

--- a/wasm/www/package-lock.json
+++ b/wasm/www/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "linguistic-time-capsule",
+  "name": "linguistic-flux-capacitor",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -4114,7 +4114,7 @@
         "invert-kv": "^2.0.0"
       }
     },
-    "linguistic-time-capsule-backend": {
+    "linguistic-flux-capacitor-backend": {
       "version": "file:../pkg"
     },
     "loader-runner": {

--- a/wasm/www/package.json
+++ b/wasm/www/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "linguistic-time-capsule",
+  "name": "linguistic-flux-capacitor",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",
@@ -12,7 +12,7 @@
   "author": "Robert Bamler <robert.bamler@gmail.com>",
   "license": "(MIT OR Apache-2.0)",
   "dependencies": {
-    "linguistic-time-capsule-backend": "file:../pkg"
+    "linguistic-flux-capacitor-backend": "file:../pkg"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^6.1.1",

--- a/wasm/www/src/backend.js
+++ b/wasm/www/src/backend.js
@@ -1,5 +1,5 @@
-import * as wasm from "linguistic-time-capsule-backend";
-import { memory } from "linguistic-time-capsule-backend/linguistic_time_capsule_backend_bg";
+import * as wasm from "linguistic-flux-capacitor-backend";
+import { memory } from "linguistic-flux-capacitor-backend/linguistic_flux_capacitor_backend_bg";
 
 // import file from "../assets/random_6_100_16.dwe";
 import dweFile from "../assets/step34000_T209_V30000_K100.dwe";

--- a/wasm/www/src/browsers/chrome.svg
+++ b/wasm/www/src/browsers/chrome.svg
@@ -12,7 +12,6 @@
    version="1.1"
    id="svg125"
    sodipodi:docname="chrome.svg"
-   inkscape:export-filename="/home/robamler/Documents/projects/linguistic-time-capsule/wasm/www/src/chrome.png"
    inkscape:export-xdpi="34.91"
    inkscape:export-ydpi="34.91"
    inkscape:version="1.0.1 (1.0.1+r73)">

--- a/wasm/www/src/browsers/edge.svg
+++ b/wasm/www/src/browsers/edge.svg
@@ -14,7 +14,6 @@
    viewBox="0 0 256 256"
    sodipodi:docname="edge.svg"
    inkscape:version="1.0.1 (1.0.1+r73)"
-   inkscape:export-filename="/home/robamler/Documents/projects/linguistic-time-capsule/wasm/www/src/edge.png"
    inkscape:export-xdpi="24"
    inkscape:export-ydpi="24">
   <metadata

--- a/wasm/www/src/browsers/firefox.svg
+++ b/wasm/www/src/browsers/firefox.svg
@@ -14,7 +14,6 @@
    viewBox="0 0 64 64"
    sodipodi:docname="firefox.svg"
    inkscape:version="1.0.1 (1.0.1+r73)"
-   inkscape:export-filename="/home/robamler/Documents/projects/linguistic-time-capsule/wasm/www/src/firefox.png"
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96">
   <sodipodi:namedview

--- a/wasm/www/src/browsers/opera.svg
+++ b/wasm/www/src/browsers/opera.svg
@@ -14,7 +14,6 @@
    id="svg650"
    sodipodi:docname="opera.svg"
    inkscape:version="1.0.1 (1.0.1+r73)"
-   inkscape:export-filename="/home/robamler/Documents/projects/linguistic-time-capsule/wasm/www/src/opera.png"
    inkscape:export-xdpi="76.989998"
    inkscape:export-ydpi="76.989998">
   <metadata

--- a/wasm/www/src/browsers/safari.svg
+++ b/wasm/www/src/browsers/safari.svg
@@ -15,7 +15,6 @@
    id="svg8"
    inkscape:version="1.0.1 (1.0.1+r73)"
    sodipodi:docname="safari.svg"
-   inkscape:export-filename="/home/robamler/Documents/projects/linguistic-time-capsule/wasm/www/src/safari.png"
    inkscape:export-xdpi="24.58"
    inkscape:export-ydpi="24.58">
   <title

--- a/wasm/www/src/favicon.svg
+++ b/wasm/www/src/favicon.svg
@@ -14,7 +14,6 @@
    id="svg8"
    inkscape:version="1.0.1 (1.0.1+r73)"
    sodipodi:docname="favicon.svg"
-   inkscape:export-filename="/home/robamler/Documents/projects/linguistic-time-capsule/wasm/www/src/favicon.png"
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96">
   <defs

--- a/wasm/www/src/index.html
+++ b/wasm/www/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>The Linguistic Time Capsule</title>
+    <title>The Linguistic Flux Capacitor</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1.0">
     <meta name="description"
         content="Explore how word meanings have changed over the past two centuries in this interactive web app.">
@@ -12,17 +12,17 @@
     <link rel="icon" type="image/png" href="favicon.png" sizes="64x64">
     <link rel="icon" type="image/png" href="favicon-256.png" sizes="256x256">
     <meta property="og:locale" content="en-US">
-    <meta property="og:site_name" content="The Linguistic Time Capsule">
-    <meta property="og:title" content="The Linguistic Time Capsule">
-    <link rel="canonical" href="https://robamler.github.io/linguistic-time-capsule">
-    <meta property="og:url" content="https://robamler.github.io/linguistic-time-capsule">
+    <meta property="og:site_name" content="The Linguistic Flux Capacitor">
+    <meta property="og:title" content="The Linguistic Flux Capacitor">
+    <link rel="canonical" href="https://robamler.github.io/linguistic-flux-capacitor">
+    <meta property="og:url" content="https://robamler.github.io/linguistic-flux-capacitor">
     <meta property="og:description"
         content="Explore how word meanings have changed over the past two centuries in this interactive web app.">
     <script type="application/ld+json">
     {
         "@context": "http://schema.org",
         "@type": "SoftwareApplication",
-        "name": "The Linguistic Time Capsule",
+        "name": "The Linguistic Flux Capacitor",
         "operatingSystem": "Web",
         "applicationCategory": "Scientific",
         "author":{
@@ -40,7 +40,7 @@
 </head>
 
 <body>
-    <a href="https://github.com/robamler/linguistic-time-capsule" class="github-corner" target="_blank"
+    <a href="https://github.com/robamler/linguistic-flux-capacitor" class="github-corner" target="_blank"
         aria-label="Contribute to project on GitHub." title="Contribute to project on GitHub."><svg width="80"
             height="80" viewBox="0 0 250 250" aria-hidden="true">
             <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
@@ -54,7 +54,7 @@
     </a>
     <div class='pageContainer'>
         <div class='appContainer'>
-            <h1>The Linguistic Time Capsule</h1>
+            <h1>The Linguistic Flux Capacitor</h1>
 
             <div class='splashScreen' id='downloadProgressPane'>
                 <div>Loading compressed machine learning model&nbsp;...</div>
@@ -111,7 +111,7 @@
                     If you're already using one of these browsers but still see this error message then you've found a
                     bug.
                     Please <a href='https://robamler.github.io/'>reach out</a> or
-                    <a href='https://github.com/robamler/linguistic-time-capsule/issues/new'>file an issue</a> so that
+                    <a href='https://github.com/robamler/linguistic-flux-capacitor/issues/new'>file an issue</a> so that
                     we can fix it.
                 </p>
             </div>
@@ -450,7 +450,7 @@
                 for some calculation.
                 We discard the decompressed part of the model immediately after the calculation so that we never have to
                 hold the entire uncompressed model in memory.
-                You can find the code <a href="https://github.com/robamler/linguistic-time-capsule" target="_blank">on
+                You can find the code <a href="https://github.com/robamler/linguistic-flux-capacitor" target="_blank">on
                     Github</a>.
             </p>
 

--- a/wasm/www/src/index.js
+++ b/wasm/www/src/index.js
@@ -225,7 +225,7 @@ let backendPromise = import("./backend.js");
     }, 0);
 
     function getLinkAndDescription() {
-        let link = 'https://robamler.github.io/linguistic-time-capsule';
+        let link = 'https://robamler.github.io/linguistic-flux-capacitor';
         if (currentWord !== '') {
             link = link + location.hash;
         }
@@ -433,23 +433,23 @@ let backendPromise = import("./backend.js");
             mainPlot.clear();
 
             if (currentWord === '') {
-                document.title = "The Linguistic Time Capsule";
+                document.title = "The Linguistic Flux Capacitor";
                 mainPlot.showInputPrompt();
                 legend.classList.add('empty');
                 if (!suppress_save_state) {
-                    history.pushState(null, "The Linguistic Time Capsule", "#");
+                    history.pushState(null, "The Linguistic Flux Capacitor", "#");
                 }
                 return;
             }
 
-            document.title = "The Linguistic Time Capsule: " + currentWord;
+            document.title = "The Linguistic Flux Capacitor: " + currentWord;
 
             if (!suppress_save_state) {
                 let stateUrl = "#v=0&c=en&w=" + encodeURIComponent(currentWord);
                 if (manualComparisons.length != 0) {
                     stateUrl = stateUrl + "&o=" + manualComparisons.map(encodeURIComponent).join("+");
                 }
-                history.pushState(null, "The Linguistic Time Capsule: " + currentWord, stateUrl);
+                history.pushState(null, "The Linguistic Flux Capacitor: " + currentWord, stateUrl);
             }
 
             legend.classList.remove('empty');


### PR DESCRIPTION

Both the former title "The Linguistic Time Capsule" as well as the
more fitting title "The Linguistic Time Machine" already get a lot of
hits on Google. The new title seems to be more unique.