### PR TITLE
Fix discrepancy between text and updated model

### DIFF
--- a/wasm/www/src/index.html
+++ b/wasm/www/src/index.html
@@ -448,8 +448,8 @@
             </p>
             <p>
                 The answer lies in a novel <strong>compression algorithm</strong> for Bayesian machine learning
-                models, which packs the 600&nbsp;million model parameters into a file that's just 26&nbsp;MB in size
-                (about 0.34&nbsp;bits per model parameter).
+                models, which packs the 600&nbsp;million model parameters into a file that's just 34&nbsp;MB in size
+                (about 0.44&nbsp;bits per model parameter).
                 The main idea is to exploit the model's varying degree of certainty about its own parameters.
                 Some model parameters are known only up to some degree of uncertainty, and we therefore encode
                 these parameters with lower accuracy than parameters about which the model is very confident.


### PR DESCRIPTION

The updated compressed model is a bit bigger than the one used during
development, and the text in section "How Does This Work?" still quoted
the old size.